### PR TITLE
Initial pass at improving code quality

### DIFF
--- a/src/main/java/songbird/command/CommandType.java
+++ b/src/main/java/songbird/command/CommandType.java
@@ -9,16 +9,31 @@ import songbird.exception.SongbirdInvalidCommandException;
  * @version CS2103T AY24/25 Semester 2
  */
 public enum CommandType {
-    BYE,
-    LIST,
-    TODO,
-    DEADLINE,
-    EVENT,
-    MARK,
-    UNMARK,
-    DELETE,
-    DUE,
-    FIND;
+    BYE("bye"),
+    LIST("list"),
+    TODO("todo"),
+    DEADLINE("deadline"),
+    EVENT("event"),
+    MARK("mark"),
+    UNMARK("unmark"),
+    DELETE("delete"),
+    DUE("due"),
+    FIND("find");
+
+    private final String value;
+
+    /**
+     * Constructs a CommandType with the given string value.
+     *
+     * @param value The string value of the CommandType.
+     */
+    CommandType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
 
     /**
      * Returns the CommandType corresponding to the given string.
@@ -29,18 +44,12 @@ public enum CommandType {
      * @throws SongbirdInvalidCommandException If the string does not match any known type.
      */
     public static CommandType fromString(String command) throws SongbirdInvalidCommandException {
-        return switch (command.toLowerCase()) {
-            case "bye" -> BYE;
-            case "list" -> LIST;
-            case "mark" -> MARK;
-            case "unmark" -> UNMARK;
-            case "todo" -> TODO;
-            case "deadline" -> DEADLINE;
-            case "event" -> EVENT;
-            case "delete" -> DELETE;
-            case "due" -> DUE;
-            case "find" -> FIND;
-            default -> throw new SongbirdInvalidCommandException();
-        };
+        for (CommandType type : CommandType.values()) {
+            if (type.getValue().equalsIgnoreCase(command)) {
+                return type;
+            }
+        }
+
+        throw new SongbirdInvalidCommandException();
     }
 }

--- a/src/main/java/songbird/parser/Parser.java
+++ b/src/main/java/songbird/parser/Parser.java
@@ -27,6 +27,10 @@ import songbird.task.TaskList;
  * @version CS2103T AY24/25 Semester 2
  */
 public class Parser {
+    private static final String BY_DELIMITER = " /by ";
+    private static final String FROM_DELIMITER = " /from ";
+    private static final String TO_DELIMITER = " /to ";
+
     private final TaskList tasks;
 
     /**
@@ -40,146 +44,186 @@ public class Parser {
 
     /**
      * Parses the user input into a command object.
-     * The command object is created based on the user input.
+     * Actual parsing is delegated to the specific command parsing methods.
      *
      * @param input The user input to be parsed.
-     * @return The command object that corresponds to the user input.
+     * @return The command object corresponding to the user input.
+     * @throws SongbirdException If the user input is invalid or malformed.
      */
     public Command parse(String input) throws SongbirdException {
         String[] inputArray = input.trim().split("\\s+", 2);
         CommandType commandType = CommandType.fromString(inputArray[0]);
+        String parameters = inputArray.length > 1 ? inputArray[1] : "";
 
         return switch (commandType) {
             case LIST -> new ListCommand(tasks);
             case BYE -> new ByeCommand();
-            case DEADLINE, EVENT, TODO -> {
-                // Check if the task description is empty
-                if (inputArray.length < 2 || inputArray[1].isBlank()) {
-                    throw new SongbirdMalformedCommandException("The description of a task cannot be empty.");
-                }
-
-                yield handleTaskAddCommands(commandType, inputArray[1]);
-            }
-            case FIND -> {
-                // Check if the keyword is empty
-                if (inputArray.length < 2) {
-                    throw new SongbirdMalformedCommandException("You must specify a keyword to search for.");
-                }
-
-                yield new FindCommand(tasks, inputArray[1]);
-            }
-            case MARK, UNMARK -> {
-                // Check if the task number is empty
-                if (inputArray.length < 2) {
-                    throw new SongbirdMalformedCommandException("You must specify a task number to modify.");
-                }
-
-                int index = Integer.parseInt(inputArray[1]) - 1; // convert to 0-based indexing for internal use
-                yield handleMarkingCommands(commandType, tasks, index);
-            }
-            case DELETE -> {
-                // Check if the task number is empty
-                if (inputArray.length < 2) {
-                    throw new SongbirdMalformedCommandException("You must specify a task number to delete.");
-                }
-
-                int index = Integer.parseInt(inputArray[1]) - 1; // convert to 0-based indexing for internal use
-                yield new TaskDeleteCommand(tasks, index);
-            }
-            case DUE -> {
-                // Check if the date is empty
-                if (inputArray.length < 2) {
-                    throw new SongbirdMalformedCommandException("You must specify a date, e.g. 'due 2025-01-17'.");
-                }
-
-                LocalDate date = DateTimeParser.parseDate(inputArray[1]);
-                yield new DueCommand(tasks, date);
-            }
+            case TODO -> parseToDoCommand(parameters);
+            case DEADLINE -> parseDeadlineCommand(parameters);
+            case EVENT -> parseEventCommand(parameters);
+            case FIND -> parseFindCommand(parameters);
+            case MARK -> parseMarkCommand(parameters);
+            case UNMARK -> parseUnmarkCommand(parameters);
+            case DELETE -> parseDeleteCommand(parameters);
+            case DUE -> parseDueCommand(parameters);
         };
     }
 
+    // COMMAND PARSER METHODS
+
     /**
-     * Handles marking and unmarking commands.
-     * The method creates the appropriate command object based on the command type. Should only be called for marking
-     * and unmarking commands.
+     * Parses the user input for a ToDoCommand.
      *
-     * @param commandType The type of command to be executed.
-     * @param tasks       The TaskList object that stores the user's tasks.
-     * @param index       The index of the task to be marked or unmarked, 0-indexed.
-     * @return The command object that corresponds to the user input.
+     * @param parameters The user input parameters for the ToDoCommand.
+     * @return The ToDoCommand object.
+     * @throws SongbirdMalformedCommandException If the user input is invalid or malformed.
      */
-    private Command handleMarkingCommands(CommandType commandType, TaskList tasks, int index) {
-        return switch (commandType) {
-            case MARK -> new TaskMarkCommand(tasks, index);
-            case UNMARK -> new TaskUnmarkCommand(tasks, index);
-            default ->
-                    throw new IllegalStateException("Unexpected command type: " + commandType); // should never get here
-        };
+    private Command parseToDoCommand(String parameters) throws SongbirdMalformedCommandException {
+        if (parameters.isBlank()) {
+            throw new SongbirdMalformedCommandException("The description of a todo cannot be empty.");
+        }
+        return new ToDoAddCommand(tasks, parameters);
     }
 
     /**
-     * Handles commands related to adding tasks.
+     * Parses the user input for a DeadlineCommand.
      *
-     * @param commandType    The type of command to be executed.
-     * @param taskParameters The parameters of the task to be added.
-     * @return The command object that corresponds to the user input.
-     * @throws SongbirdException If the task parameters are empty or malformed.
+     * @param parameters The user input parameters for the DeadlineCommand.
+     * @return The DeadlineCommand object.
+     * @throws SongbirdException If the user input is invalid or malformed.
      */
-    private Command handleTaskAddCommands(CommandType commandType, String taskParameters) throws SongbirdException {
-        return switch (commandType) {
-            case TODO -> new ToDoAddCommand(tasks, taskParameters);
+    private Command parseDeadlineCommand(String parameters) throws SongbirdException {
+        String[] parts = parameters.split(BY_DELIMITER, 2);
+        if (parts.length < 2 || parts[1].trim().isEmpty()) {
+            throw new SongbirdMalformedCommandException(
+                    "The deadline task must have a deadline, formatted as '/by YYYY-MM-DD' (e.g. 2025-01-30).");
+        }
+        String description = parts[0].trim();
+        LocalDateTime deadline = DateTimeParser.parseDateTime(parts[1].trim());
+        return new DeadlineAddCommand(tasks, description, deadline);
+    }
 
-            case DEADLINE -> {
-                // must be in format: <DESCRIPTION> /by <DEADLINE>
-                String[] parts = taskParameters.split(" /by ", 2);
+    /**
+     * Parses the user input for an EventCommand.
+     *
+     * @param parameters The user input parameters for the EventCommand.
+     * @return The EventCommand object.
+     * @throws SongbirdException If the user input is invalid or malformed.
+     */
+    private Command parseEventCommand(String parameters) throws SongbirdException {
+        if (!parameters.contains(FROM_DELIMITER) || !parameters.contains(TO_DELIMITER)) {
+            throw new SongbirdMalformedCommandException("The event task must have a start and end time, "
+                    + "formatted as '/from YYYY-MM-DD HH:MM /to YYYY-MM-DD HH:MM'.");
+        }
+        String[] fromParts = parameters.split(FROM_DELIMITER, 2);
+        String[] toParts;
+        String eventDescription;
+        String eventStartString;
+        String eventEndString;
 
-                // Check if the deadline task has a deadline
-                if (parts.length < 2 || parts[1].isEmpty()) {
-                    throw new SongbirdMalformedCommandException("The deadline task must have a deadline, formatted as "
-                            + "'/by YYYY-MM-DD' (e.g. 2025-01-30).");
-                }
+        if (fromParts[1].contains(TO_DELIMITER)) {
+            eventDescription = fromParts[0].trim();
+            toParts = fromParts[1].split(TO_DELIMITER, 2);
+            eventStartString = toParts[0].trim();
+            eventEndString = toParts[1].trim();
+        } else {
+            eventStartString = fromParts[1].trim();
+            toParts = fromParts[0].split(TO_DELIMITER, 2);
+            eventDescription = toParts[1].trim();
+            eventEndString = toParts[0].trim();
+        }
+        LocalDateTime eventStart = DateTimeParser.parseDateTime(eventStartString);
+        LocalDateTime eventEnd = DateTimeParser.parseDateTime(eventEndString);
+        return new EventAddCommand(tasks, eventDescription, eventStart, eventEnd);
+    }
 
-                String description = parts[0].trim();
-                LocalDateTime deadline = DateTimeParser.parseDateTime(parts[1].trim());
-                yield new DeadlineAddCommand(tasks, description, deadline);
-            }
+    /**
+     * Parses the user input for a FindCommand.
+     *
+     * @param parameters The user input parameters for the FindCommand.
+     * @return The FindCommand object.
+     * @throws SongbirdMalformedCommandException If the user input is invalid or malformed.
+     */
+    private Command parseFindCommand(String parameters) throws SongbirdMalformedCommandException {
+        if (parameters.isBlank()) {
+            throw new SongbirdMalformedCommandException("You must specify a keyword to search for.");
+        }
+        return new FindCommand(tasks, parameters);
+    }
 
-            case EVENT -> {
-                String eventDescription;
-                String eventStartString;
-                String eventEndString;
+    /**
+     * Parses the user input for a MarkCommand.
+     *
+     * @param parameters The user input parameters for the MarkCommand.
+     * @return The MarkCommand object.
+     * @throws SongbirdMalformedCommandException If the user input is invalid or malformed.
+     */
+    private Command parseMarkCommand(String parameters) throws SongbirdMalformedCommandException {
+        return parseTaskIndexCommand(parameters, CommandType.MARK);
+    }
 
-                // must be in format: <DESCRIPTION> /from <START> /to <END>
-                if (!taskParameters.contains(" /from ") || !taskParameters.contains(" /to ")) {
-                    throw new SongbirdMalformedCommandException("The event task must have a start and end time, "
-                            + "formatted as '/from YYYY-MM-DD HH:MM /to YYYY-MM-DD HH:MM'.");
-                }
+    /**
+     * Parses the user input for an UnmarkCommand.
+     *
+     * @param parameters The user input parameters for the UnmarkCommand.
+     * @return The UnmarkCommand object.
+     * @throws SongbirdMalformedCommandException If the user input is invalid or malformed.
+     */
+    private Command parseUnmarkCommand(String parameters) throws SongbirdMalformedCommandException {
+        return parseTaskIndexCommand(parameters, CommandType.UNMARK);
+    }
 
-                // Split the taskParameters string
-                String[] fromParts = taskParameters.split(" /from ", 2);
-                String[] toParts;
+    /**
+     * Parses the user input for a DeleteCommand.
+     *
+     * @param parameters The user input parameters for the DeleteCommand.
+     * @return The DeleteCommand object.
+     * @throws SongbirdMalformedCommandException If the user input is invalid or malformed.
+     */
+    private Command parseDeleteCommand(String parameters) throws SongbirdMalformedCommandException {
+        return parseTaskIndexCommand(parameters, CommandType.DELETE);
+    }
 
-                // extract the description, start, and end times, no matter the order
-                if (fromParts[1].contains(" /to ")) {
-                    // if /from comes before /to
-                    eventDescription = fromParts[0].trim();
-                    toParts = fromParts[1].split(" /to ", 2);
-                    eventStartString = toParts[0].trim();
-                } else {
-                    // if /to comes before /from
-                    eventStartString = fromParts[1].trim();
-                    toParts = fromParts[0].split(" /to ", 2);
-                    eventDescription = toParts[0].trim();
-                }
-                eventEndString = toParts[1].trim();
+    /**
+     * Parses the user input for commands that require a task index.
+     *
+     * @param parameters The user input parameters for the command.
+     * @param type The CommandType of the command.
+     * @return The Command object.
+     * @throws SongbirdMalformedCommandException If the user input is invalid or malformed.
+     */
+    private Command parseTaskIndexCommand(String parameters,
+                                          CommandType type) throws SongbirdMalformedCommandException {
+        if (parameters.isBlank()) {
+            throw new SongbirdMalformedCommandException("You must specify a task number.");
+        }
+        try {
+            int index = Integer.parseInt(parameters) - 1;
+            return switch (type) {
+                case MARK -> new TaskMarkCommand(tasks, index);
+                case UNMARK -> new TaskUnmarkCommand(tasks, index);
+                case DELETE -> new TaskDeleteCommand(tasks, index);
+                default -> throw new IllegalStateException("Unexpected command type: " + type);
+            };
 
-                LocalDateTime eventStart = DateTimeParser.parseDateTime(eventStartString);
-                LocalDateTime eventEnd = DateTimeParser.parseDateTime(eventEndString);
+        } catch (NumberFormatException e) {
+            throw new SongbirdMalformedCommandException("Invalid task number: " + parameters);
+        }
+    }
 
-                yield new EventAddCommand(tasks, eventDescription, eventStart, eventEnd);
-            }
-            default ->
-                    throw new IllegalStateException("Unexpected command type: " + commandType); // should never get here
-        };
+    /**
+     * Parses the user input for a DueCommand.
+     * The user input should be a date in the format 'YYYY-MM-DD'.
+     *
+     * @param parameters The user input parameters for the DueCommand.
+     * @return The DueCommand object.
+     * @throws SongbirdException If the user input is invalid or malformed.
+     */
+    private Command parseDueCommand(String parameters) throws SongbirdException {
+        if (parameters.isBlank()) {
+            throw new SongbirdMalformedCommandException("You must specify a date, e.g. 'due 2025-01-17'.");
+        }
+        LocalDate date = DateTimeParser.parseDate(parameters);
+        return new DueCommand(tasks, date);
     }
 }

--- a/src/main/java/songbird/task/TaskList.java
+++ b/src/main/java/songbird/task/TaskList.java
@@ -140,15 +140,13 @@ public class TaskList {
     public List<Task> getTasksByDate(LocalDate date) {
         return this.tasks.stream()
                 .filter(task -> {
-                    if (task instanceof DeadlineTask dt) {
-                        return dt.getDeadline().toLocalDate().isEqual(date);
-                    } else if (task instanceof EventTask et) {
-                        LocalDate start = et.getEventStart().toLocalDate();
-                        LocalDate end = et.getEventEnd().toLocalDate();
-                        // check if current date is between start and end (inclusive)
+                    if (task instanceof DeadlineTask deadlineTask) {
+                        return deadlineTask.getDeadline().toLocalDate().isEqual(date);
+                    } else if (task instanceof EventTask eventTask) {
+                        LocalDate start = eventTask.getEventStart().toLocalDate();
+                        LocalDate end = eventTask.getEventEnd().toLocalDate();
                         return !date.isBefore(start) && !date.isAfter(end);
                     }
-                    // ignore other task types
                     return false;
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
This PR will contain the initial pass at improving code quality in the project.

Primarily, this focuses on fixing the issues surrounding SLAP and long methods within `Parser`. Previously, this was handled within a large monolithic method `Parser::parse`, which broke both the long method and SLAP rules. We now hand off the parsing of each command type to its own shorter helper function, and thus significantly reduce the length and complexity of `Parser::parse`.

Other miscellaneous fixes for code quality include improving variable names in `TaskList` and improving the handling of string descriptions in the `CommandType` enum.